### PR TITLE
remove version from jar used in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV MICROSERVICE_HOME /usr/microservices
 ENV OMP_THREAD_LIMIT 1
 
 # Set the name of the jar
-ENV APP_FILE ocr-api-unversioned.jar
+ENV APP_FILE ocr-api.jar
 
 ENV LC_ALL C
 
@@ -41,7 +41,7 @@ EXPOSE 8080
 COPY docker-resources/configure-maven /usr/local/bin/configure-maven
 
 # Copy our JAR
-COPY target/$APP_FILE /app.jar
+COPY $APP_FILE /app.jar
 
 # Launch the Spring Boot application
 ENV JAVA_OPTS=""

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-unit: clean
 
 .PHONY: dev
 dev: clean
-	mvn package -DskipTests=true
+	mvn package
 	cp target/$(artifact_name)-unversioned.jar $(artifact_name).jar
 
 .PHONY: package

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The initial drop of this microservice converts TIFF files to text.
 
 ## Usage
 
-- Run `mvn clean package` to build JAR and run the unit tests **(using Java 11)**
+- Run `make dev` to build JAR (versioned in target and unversioned in top level d) and run the unit tests **(using Java 11)**
 - Run `docker build -t ocr-api .` to build the docker image
 - Run `docker run -e HUMAN_LOG=1 -e LOGLEVEL=debug -t -i -p 8080:8080 ocr-api` to run the docker image
 


### PR DESCRIPTION
IVP-1168

Remove the jar file version from the docker file to make it easier to run (the zip itself is versioned and other projects do it this way)