### PR TITLE
Fix sonar pr branch from master to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,14 @@
         <tess4j.version>4.5.3</tess4j.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>sonar-pr-analysis</id>
+            <properties>
+                <sonar.pullrequest.base>main</sonar.pullrequest.base>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
 


### PR DESCRIPTION
Adds a profile to the pom which points sonar-pr-analysis to main instead of master