### PR TITLE
Add a statistics endpoint for the ocr-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OCR_TESSERACT_THREAD_POOL_SIZE              | Number of threads to run the Tesse
 Name                       | Description
 ---------------------------| ------------------------------------------------------------
 queue_size                 | The number of items on the internal queue waiting to be processed by the Tesseract threads
+instance_uuid              | UUID for when multiple instance of ocr-api are running in the same AWS ECS Cluster (or instance restarts)
 tesseract_thread_pool_size | The number of Java threads used in the Tesseract image to text conversion (static)  
 
 ## Testing Locally

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ The initial drop of this microservice converts TIFF files to text.
 
 ## Usage
 
+Set the environmental variables OCR_TESSERACT_THREAD_POOL_SIZE, HUMAN_LOG and LOGLEVEL
+
 - Run `make dev` to build JAR (versioned in target and unversioned in top level d) and run the unit tests **(using Java 11)**
 - Run `docker build -t ocr-api .` to build the docker image
-- Run `docker run -e HUMAN_LOG=1 -e LOGLEVEL=debug -t -i -p 8080:8080 ocr-api` to run the docker image
+- Run `docker run -e OCR_TESSERACT_THREAD_POOL_SIZE -e HUMAN_LOG -e LOGLEVEL -t -i -p 8080:8080 ocr-api` to run the docker image
 
 ## Tesseract Training data
 
@@ -44,11 +46,18 @@ See:
 
 ## Environment Variables
 
-The following is a list of mandatory environment variables for the service to run:
+The following is a list of application specific environment variables for the service to run:
 
 Name                                        | Description                                                               | Example Value
 ------------------------------------------- | ------------------------------------------------------------------------- | ------------------------
 OCR_TESSERACT_THREAD_POOL_SIZE              | Number of threads to run the Tesseract Conversion process                 | 4  (default value)
+
+## The stats end point
+
+Name                       | Description
+---------------------------| ------------------------------------------------------------
+queue_size                 | The number of items on the internal queue waiting to be processed by the Tesseract threads
+tesseract_thread_pool_size | The number of Java threads used in the Tesseract image to text conversion (static)  
 
 ## Testing Locally
 
@@ -70,6 +79,12 @@ For heath check:
 
 ``` bash
 curl -w '%{http_code}' http://localhost:8080/ocr-api/healthcheck
+```
+
+For statistics endpoint:
+
+``` bash
+curl -w '%{http_code}' http://localhost:8080/ocr-api/statistics
 ```
 
 ### Using maven

--- a/src/main/java/uk/gov/companieshouse/ocr/api/ThreadConfig.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/ThreadConfig.java
@@ -20,12 +20,23 @@ public class ThreadConfig {
 
     private EnvironmentReader reader = new EnvironmentReaderImpl();
 
+    private final int threadPoolSize;
+
+    public ThreadConfig() {
+        this.threadPoolSize = findThreadPoolSize();
+    }
+
+    private int findThreadPoolSize() {
+
+        var configuredThreadPoolSize = reader.getOptionalInteger("OCR_TESSERACT_THREAD_POOL_SIZE");
+        return (configuredThreadPoolSize != null) ? configuredThreadPoolSize :  DEFAULT_THREAD_POOL_SIZE;
+    }
+
     @Bean (name="taskExecutor")
     public ThreadPoolTaskExecutor taskExecutor() {
 
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
-        var threadPoolSize = getThreadPoolSize();
         var processors = Runtime.getRuntime().availableProcessors();
         LOG.info("Using a thread pool of [" + threadPoolSize + "] with available processors of [" + processors + "]");
 
@@ -36,10 +47,8 @@ public class ThreadConfig {
         return executor;
     }
 
-    private int getThreadPoolSize() {
-
-        var configuredThreadPoolSize = reader.getOptionalInteger("OCR_TESSERACT_THREAD_POOL_SIZE");
-        
-        return (configuredThreadPoolSize != null) ? configuredThreadPoolSize :  DEFAULT_THREAD_POOL_SIZE;
+    public int getThreadPoolSize() {
+        return threadPoolSize;
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/common/ErrorResponseDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/common/ErrorResponseDTO.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  *  The response to the client when an error occurs (the context and/or response id might not be present due to the asynchonous nature of the processing in this microservice)
  */
-public class ErrorResponseDTO {
+public class ErrorResponseDto {
 
     @JsonProperty("context_id")
     private String contextId;

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ExtractTextResultDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ExtractTextResultDTO.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Results returned to a client on a successful API call
  */
-public class ExtractTextResultDTO {
+public class ExtractTextResultDto {
 
     /**
      *  The input contextId of the OCR request

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.ocr.api.OcrApiApplication;
-import uk.gov.companieshouse.ocr.api.common.ErrorResponseDTO;
+import uk.gov.companieshouse.ocr.api.common.ErrorResponseDto;
 
 @RequestMapping("${api.endpoint}")
 @RestController
@@ -43,7 +43,7 @@ public class ImageOcrApiController {
     private ImageOcrTransformer transformer = new ImageOcrTransformer();
 
     @PostMapping(TIFF_EXTRACT_TEXT_PARTIAL_URL)
-    public @ResponseBody ResponseEntity<ExtractTextResultDTO> extractTextFromTiff(
+    public @ResponseBody ResponseEntity<ExtractTextResultDto> extractTextFromTiff(
             @RequestParam(FILE_REQUEST_PARAMETER_NAME) MultipartFile file, 
             @RequestParam(RESPONSE_ID_REQUEST_PARAMETER_NAME) String responseId,
             @RequestParam(name = CONTEXT_ID_REQUEST_PARAMETER_NAME, required = false) String contextId
@@ -75,9 +75,9 @@ public class ImageOcrApiController {
      Occurs when the  `.join()` method is called after calling an `async` method AND an untrapped exception is thown within that method
      */
     @ExceptionHandler(CompletionException.class)
-    public ResponseEntity<ErrorResponseDTO> handleCompletionException(CompletionException e) {
+    public ResponseEntity<ErrorResponseDto> handleCompletionException(CompletionException e) {
 
-        var errorResponse = new ErrorResponseDTO();
+        var errorResponse = new ErrorResponseDto();
         if (e.getCause() instanceof TextConversionException) {
 
             var cause = (TextConversionException) e.getCause();
@@ -95,11 +95,11 @@ public class ImageOcrApiController {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDTO> uncaughtException(Exception e) {
+    public ResponseEntity<ErrorResponseDto> uncaughtException(Exception e) {
 
         LOG.error(null, e);
 
-        var errorResponse = new ErrorResponseDTO();
+        var errorResponse = new ErrorResponseDto();
         errorResponse.setErrorMessage(CONTROLLER_ERROR_MESSAGE);
 
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
@@ -56,7 +56,7 @@ public class ImageOcrApiController {
             contextId = responseId;
         }
         
-        LOG.infoContext(contextId,"Processing file [" + file.getOriginalFilename() + "] Content type [" + file.getContentType() + "]", null);
+        LOG.infoContext(contextId,"Received from client file [" + file.getOriginalFilename() + "] Content type [" + file.getContentType() + "]", null);
 
         var timeOnQueueStopWatch = new StopWatch();
         timeOnQueueStopWatch.start();
@@ -65,7 +65,7 @@ public class ImageOcrApiController {
         controllerStopWatch.stop();
         result.setTotalProcessingTimeMs(controllerStopWatch.getTime());
     
-        LOG.infoContext(contextId, "Finished processing file " + file.getOriginalFilename() + " - time to run " + (controllerStopWatch.getTime()) + " (ms) " + "[ " +
+        LOG.infoContext(contextId, "Finished file " + file.getOriginalFilename() + " - time to run " + (controllerStopWatch.getTime()) + " (ms) " + "[ " +
            controllerStopWatch.toString() + "]", null);
 
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrService.java
@@ -34,7 +34,7 @@ public class ImageOcrService {
     extractTextFromImage(String contextId, MultipartFile file, String responseId, StopWatch timeOnQueueStopWatch) throws IOException {
 
         timeOnQueueStopWatch.stop();
-        LOG.infoContext(contextId, "Time waiting on queue " + timeOnQueueStopWatch.toString(), null);
+        LOG.infoContext(contextId, "Converting File to Text - Time waiting on queue " + timeOnQueueStopWatch.toString(), null);
 
         final var textConversionResult = new TextConversionResult(contextId, responseId, timeOnQueueStopWatch.getTime()); 
 

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrTransformer.java
@@ -2,21 +2,21 @@ package uk.gov.companieshouse.ocr.api.image.extracttext;
 
 public class ImageOcrTransformer {
 
-    public ExtractTextResultDTO mapModelToApi(TextConversionResult textConversionResult) {
+    public ExtractTextResultDto mapModelToApi(TextConversionResult textConversionResult) {
  
-        var extractTextResultDTO = new ExtractTextResultDTO();
+        var extractTextResultDto = new ExtractTextResultDto();
 
-        extractTextResultDTO.setExtractedText(textConversionResult.getExtractedText());
+        extractTextResultDto.setExtractedText(textConversionResult.getExtractedText());
 
-        extractTextResultDTO.setAverageConfidenceScore(Math.round(textConversionResult.getDocumentAverageConfidence()));
-        extractTextResultDTO.setLowestConfidenceScore(Math.round(textConversionResult.getDocumentMinimumConfidence()));
+        extractTextResultDto.setAverageConfidenceScore(Math.round(textConversionResult.getDocumentAverageConfidence()));
+        extractTextResultDto.setLowestConfidenceScore(Math.round(textConversionResult.getDocumentMinimumConfidence()));
 
-        extractTextResultDTO.setOcrProcessingTimeMs(textConversionResult.getExtractTextProcessingTime());
+        extractTextResultDto.setOcrProcessingTimeMs(textConversionResult.getExtractTextProcessingTime());
 
-        extractTextResultDTO.setContextId(textConversionResult.getContextId());
-        extractTextResultDTO.setResponseId(textConversionResult.getResponseId());
+        extractTextResultDto.setContextId(textConversionResult.getContextId());
+        extractTextResultDto.setResponseId(textConversionResult.getResponseId());
 
-        return extractTextResultDTO;
+        return extractTextResultDto;
     }
     
 }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsController.java
@@ -18,9 +18,9 @@ public class StatisticsController {
     private StatisticsService statisticsService;
 
     @GetMapping(STATS_PARTIAL_URL)
-    public @ResponseBody ResponseEntity<StatisticsDTO> getStatistics() {
+    public @ResponseBody ResponseEntity<StatisticsDto> getStatistics() {
 
-        return new ResponseEntity<>(statisticsService.create(), HttpStatus.OK);
+        return new ResponseEntity<>(statisticsService.generateStatistics(), HttpStatus.OK);
     }
     
 }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsController.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.ocr.api.statistics;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("${api.endpoint}")
+@RestController
+public class StatisticsController {
+
+    public static final String STATS_PARTIAL_URL = "/statistics";
+    
+    @Autowired
+    private StatisticsService statisticsService;
+
+    @GetMapping(STATS_PARTIAL_URL)
+    public @ResponseBody ResponseEntity<StatisticsDTO> getStatistics() {
+
+        return new ResponseEntity<>(statisticsService.create(), HttpStatus.OK);
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.ocr.api.statistics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StatisticsDTO {
+
+    @JsonProperty("queue_size")
+    int queueSize;
+
+    @JsonProperty("tesseract_thread_pool_size")
+    int tesseractThreadPoolSize;
+
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    public void setQueueSize(int queueSize) {
+        this.queueSize = queueSize;
+    }
+
+    public int getTesseractThreadPoolSize() {
+        return tesseractThreadPoolSize;
+    }
+
+    public void setTesseractThreadPoolSize(int tesseractThreadPoolSize) {
+        this.tesseractThreadPoolSize = tesseractThreadPoolSize;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
@@ -7,6 +7,9 @@ public class StatisticsDTO {
     @JsonProperty("queue_size")
     int queueSize;
 
+    @JsonProperty("instance_uuid")
+    String instanceUuid;
+
     @JsonProperty("tesseract_thread_pool_size")
     int tesseractThreadPoolSize;
 
@@ -17,6 +20,14 @@ public class StatisticsDTO {
     public void setQueueSize(int queueSize) {
         this.queueSize = queueSize;
     }
+
+    public String getInstanceUuid() {
+        return instanceUuid;
+    }
+
+    public void setInstanceUuid(String instanceUuid) {
+        this.instanceUuid = instanceUuid;
+    } 
 
     public int getTesseractThreadPoolSize() {
         return tesseractThreadPoolSize;

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
@@ -4,22 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StatisticsDTO {
 
-    @JsonProperty("queue_size")
-    int queueSize;
-
     @JsonProperty("instance_uuid")
     String instanceUuid;
 
+    @JsonProperty("queue_size")
+    int queueSize;
+
     @JsonProperty("tesseract_thread_pool_size")
     int tesseractThreadPoolSize;
-
-    public int getQueueSize() {
-        return queueSize;
-    }
-
-    public void setQueueSize(int queueSize) {
-        this.queueSize = queueSize;
-    }
 
     public String getInstanceUuid() {
         return instanceUuid;
@@ -28,6 +20,14 @@ public class StatisticsDTO {
     public void setInstanceUuid(String instanceUuid) {
         this.instanceUuid = instanceUuid;
     } 
+
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    public void setQueueSize(int queueSize) {
+        this.queueSize = queueSize;
+    }
 
     public int getTesseractThreadPoolSize() {
         return tesseractThreadPoolSize;

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDTO.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.ocr.api.statistics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class StatisticsDTO {
+public class StatisticsDto {
 
     @JsonProperty("instance_uuid")
     String instanceUuid;

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
@@ -23,8 +23,8 @@ public class StatisticsService {
 
         StatisticsDTO statistics = new StatisticsDTO();
         statistics.setQueueSize(taskExecutor.getThreadPoolExecutor().getQueue().size());
-        statistics.setInstanceUuid(INSTANCE_UUID);
         statistics.setTesseractThreadPoolSize(threadConfig.getThreadPoolSize());
+        statistics.setInstanceUuid(INSTANCE_UUID);
 
         return statistics;           
     }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.ocr.api.statistics;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.ocr.api.ThreadConfig;
+
+@Service
+public class StatisticsService {
+
+    @Autowired
+    private ThreadConfig threadConfig;
+
+    @Autowired
+    private ThreadPoolTaskExecutor taskExecutor;
+
+    public StatisticsDTO create() {
+
+        StatisticsDTO statistics = new StatisticsDTO();
+        statistics.setQueueSize(taskExecutor.getThreadPoolExecutor().getQueue().size());
+        statistics.setTesseractThreadPoolSize(threadConfig.getThreadPoolSize());
+
+        return statistics;           
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.ocr.api.statistics;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,8 @@ import uk.gov.companieshouse.ocr.api.ThreadConfig;
 
 @Service
 public class StatisticsService {
+
+    private static final String INSTANCE_UUID = UUID.randomUUID().toString();
 
     @Autowired
     private ThreadConfig threadConfig;
@@ -19,6 +23,7 @@ public class StatisticsService {
 
         StatisticsDTO statistics = new StatisticsDTO();
         statistics.setQueueSize(taskExecutor.getThreadPoolExecutor().getQueue().size());
+        statistics.setInstanceUuid(INSTANCE_UUID);
         statistics.setTesseractThreadPoolSize(threadConfig.getThreadPoolSize());
 
         return statistics;           

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsService.java
@@ -19,9 +19,9 @@ public class StatisticsService {
     @Autowired
     private ThreadPoolTaskExecutor taskExecutor;
 
-    public StatisticsDTO create() {
+    public StatisticsDto generateStatistics() {
 
-        StatisticsDTO statistics = new StatisticsDTO();
+        StatisticsDto statistics = new StatisticsDto();
         statistics.setQueueSize(taskExecutor.getThreadPoolExecutor().getQueue().size());
         statistics.setTesseractThreadPoolSize(threadConfig.getThreadPoolSize());
         statistics.setInstanceUuid(INSTANCE_UUID);

--- a/src/test/java/uk/gov/companieshouse/ocr/api/IntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/IntegrationTest.java
@@ -22,7 +22,7 @@ import org.springframework.web.client.RestTemplate;
 
 import net.sourceforge.tess4j.TesseractException;
 import uk.gov.companieshouse.ocr.api.groups.TestType;
-import uk.gov.companieshouse.ocr.api.image.extracttext.ExtractTextResultDTO;
+import uk.gov.companieshouse.ocr.api.image.extracttext.ExtractTextResultDto;
 import uk.gov.companieshouse.ocr.api.image.extracttext.ImageOcrApiController;
 
 @Tag(TestType.INTEGRATION)
@@ -54,7 +54,7 @@ public class IntegrationTest {
         return new FileSystemResource(filePath);
     }
 
-    private ExtractTextResultDTO extractText(FileSystemResource fileBytes) {
+    private ExtractTextResultDto extractText(FileSystemResource fileBytes) {
 
         var headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -74,7 +74,7 @@ public class IntegrationTest {
         System.out.println("Using API URL [" + url + "]");
 
         var restTemplate = new RestTemplate();
-        var response = restTemplate.postForEntity(url, requestEntity, ExtractTextResultDTO.class);
+        var response = restTemplate.postForEntity(url, requestEntity, ExtractTextResultDto.class);
 
         return response.getBody();
     }

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiControllerTest.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.ocr.api.groups.TestType;
 @Tag(TestType.UNIT)
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = ImageOcrApiController.class)
-public class ImageOcrApiControllerTest {
+class ImageOcrApiControllerTest {
 
     private static final String CONTEXT_ID = "test-context-id";
     private static final String FILE_TEXT = "I am a tiff image of articles of association";

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResultTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResultTest.java
@@ -26,7 +26,7 @@ public class TextConversionResultTest {
     }
 
     @Test
-    public void singlePageResults5Datapoints() {
+    void singlePageResults5Datapoints() {
 
         textConversionResult.addPage();
 
@@ -56,7 +56,7 @@ public class TextConversionResultTest {
     }
 
     @Test
-    public void multiPageResultsDatapoints() {
+    void multiPageResultsDatapoints() {
 
         textConversionResult.addPage();
 
@@ -90,7 +90,7 @@ public class TextConversionResultTest {
     }
 
     @Test
-    public void multiPageResultsWithBlankPageDatapoints() {
+    void multiPageResultsWithBlankPageDatapoints() {
 
         textConversionResult.addPage();
 
@@ -126,7 +126,7 @@ public class TextConversionResultTest {
     }
 
     @Test
-    public void blankDocument() {
+    void blankDocument() {
 
         textConversionResult.addPage();
 

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.ocr.api.statistics;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import uk.gov.companieshouse.ocr.api.groups.TestType;
+
+@Tag(TestType.UNIT)
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = StatisticsController.class)
+public class StatisticsControllerTest {
+
+	private final static String TEST_UUID = "UUID_123";
+	private final static int TEST_QUEUE_SIZE = 1;
+	private final static int TEST_TESSERACT_POOL_SIZE = 3;
+
+	@Autowired
+	private MockMvc mockMvc;
+	
+	@Value("${api.endpoint}")
+    private String apiEndpoint;
+
+	@MockBean
+    private StatisticsService mockStatisticsService;
+
+	@Test
+	public void shouldGetStatistics() throws Exception {
+
+		StatisticsDTO testStatistics = new StatisticsDTO();
+		testStatistics.setInstanceUuid(TEST_UUID);
+		testStatistics.setQueueSize(TEST_QUEUE_SIZE);
+		testStatistics.setTesseractThreadPoolSize(TEST_TESSERACT_POOL_SIZE);
+		
+		when(mockStatisticsService.create()).thenReturn(testStatistics);
+
+		mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + StatisticsController.STATS_PARTIAL_URL))
+		.andExpect(status().isOk())
+		.andExpect(jsonPath("$.instance_uuid", is(TEST_UUID)))
+		.andExpect(jsonPath("$.queue_size", is(TEST_QUEUE_SIZE)))
+		.andExpect(jsonPath("$.tesseract_thread_pool_size", is(TEST_TESSERACT_POOL_SIZE)));
+	}
+ }
+

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
@@ -23,34 +23,32 @@ import uk.gov.companieshouse.ocr.api.groups.TestType;
 @WebMvcTest(controllers = StatisticsController.class)
 public class StatisticsControllerTest {
 
-	private final static String TEST_UUID = "UUID_123";
-	private final static int TEST_QUEUE_SIZE = 1;
-	private final static int TEST_TESSERACT_POOL_SIZE = 3;
+    private final static String TEST_UUID = "UUID_123";
+    private final static int TEST_QUEUE_SIZE = 1;
+    private final static int TEST_TESSERACT_POOL_SIZE = 3;
 
-	@Autowired
-	private MockMvc mockMvc;
-	
-	@Value("${api.endpoint}")
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Value("${api.endpoint}")
     private String apiEndpoint;
 
-	@MockBean
+    @MockBean
     private StatisticsService mockStatisticsService;
 
-	@Test
-	public void shouldGetStatistics() throws Exception {
+    @Test
+    void shouldGetStatistics() throws Exception {
 
-		StatisticsDTO testStatistics = new StatisticsDTO();
-		testStatistics.setInstanceUuid(TEST_UUID);
-		testStatistics.setQueueSize(TEST_QUEUE_SIZE);
-		testStatistics.setTesseractThreadPoolSize(TEST_TESSERACT_POOL_SIZE);
-		
-		when(mockStatisticsService.create()).thenReturn(testStatistics);
+        StatisticsDTO testStatistics = new StatisticsDTO();
+        testStatistics.setInstanceUuid(TEST_UUID);
+        testStatistics.setQueueSize(TEST_QUEUE_SIZE);
+        testStatistics.setTesseractThreadPoolSize(TEST_TESSERACT_POOL_SIZE);
 
-		mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + StatisticsController.STATS_PARTIAL_URL))
-		.andExpect(status().isOk())
-		.andExpect(jsonPath("$.instance_uuid", is(TEST_UUID)))
-		.andExpect(jsonPath("$.queue_size", is(TEST_QUEUE_SIZE)))
-		.andExpect(jsonPath("$.tesseract_thread_pool_size", is(TEST_TESSERACT_POOL_SIZE)));
-	}
- }
+        when(mockStatisticsService.create()).thenReturn(testStatistics);
 
+        mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + StatisticsController.STATS_PARTIAL_URL))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.instance_uuid", is(TEST_UUID)))
+                .andExpect(jsonPath("$.queue_size", is(TEST_QUEUE_SIZE)))
+                .andExpect(jsonPath("$.tesseract_thread_pool_size", is(TEST_TESSERACT_POOL_SIZE)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
@@ -39,12 +39,12 @@ public class StatisticsControllerTest {
     @Test
     void shouldGetStatistics() throws Exception {
 
-        StatisticsDTO testStatistics = new StatisticsDTO();
+        StatisticsDto testStatistics = new StatisticsDto();
         testStatistics.setInstanceUuid(TEST_UUID);
         testStatistics.setQueueSize(TEST_QUEUE_SIZE);
         testStatistics.setTesseractThreadPoolSize(TEST_TESSERACT_POOL_SIZE);
 
-        when(mockStatisticsService.create()).thenReturn(testStatistics);
+        when(mockStatisticsService.generateStatistics()).thenReturn(testStatistics);
 
         mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + StatisticsController.STATS_PARTIAL_URL))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.instance_uuid", is(TEST_UUID)))

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
@@ -34,17 +34,17 @@ public class StatisticsServiceTest {
     private StatisticsService statisticsService;
 
     @Test
-	void create() {
+    void create() {
 
         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
         when(mockTaskExecutor.getThreadPoolExecutor()).thenReturn(threadPoolExecutor);
         when(mockThreadConfig.getThreadPoolSize()).thenReturn(TEST_TESSERACT_POOL_SIZE);
 
-		StatisticsDTO statistics = statisticsService.create();
+        StatisticsDTO statistics = statisticsService.create();
 
-		assertNotNull(statistics.getInstanceUuid());
-		assertEquals(0, statistics.getQueueSize());
-		assertEquals(TEST_TESSERACT_POOL_SIZE, statistics.getTesseractThreadPoolSize());
-	}
+        assertNotNull(statistics.getInstanceUuid());
+        assertEquals(0, statistics.getQueueSize());
+        assertEquals(TEST_TESSERACT_POOL_SIZE, statistics.getTesseractThreadPoolSize());
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.ocr.api.statistics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import uk.gov.companieshouse.ocr.api.ThreadConfig;
+import uk.gov.companieshouse.ocr.api.groups.TestType;
+
+@Tag(TestType.UNIT)
+@ExtendWith(MockitoExtension.class)
+public class StatisticsServiceTest {
+
+    private final static int TEST_TESSERACT_POOL_SIZE = 3;
+
+    @Mock
+    private ThreadConfig mockThreadConfig;
+
+    @Mock
+    private ThreadPoolTaskExecutor mockTaskExecutor;
+
+    @InjectMocks
+    private StatisticsService statisticsService;
+
+    @Test
+	void create() {
+
+        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
+        when(mockTaskExecutor.getThreadPoolExecutor()).thenReturn(threadPoolExecutor);
+        when(mockThreadConfig.getThreadPoolSize()).thenReturn(TEST_TESSERACT_POOL_SIZE);
+
+		StatisticsDTO statistics = statisticsService.create();
+
+		assertNotNull(statistics.getInstanceUuid());
+		assertEquals(0, statistics.getQueueSize());
+		assertEquals(TEST_TESSERACT_POOL_SIZE, statistics.getTesseractThreadPoolSize());
+	}
+
+}

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
@@ -34,13 +34,13 @@ public class StatisticsServiceTest {
     private StatisticsService statisticsService;
 
     @Test
-    void create() {
+    void generateStatistics() {
 
         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
         when(mockTaskExecutor.getThreadPoolExecutor()).thenReturn(threadPoolExecutor);
         when(mockThreadConfig.getThreadPoolSize()).thenReturn(TEST_TESSERACT_POOL_SIZE);
 
-        StatisticsDTO statistics = statisticsService.create();
+        StatisticsDto statistics = statisticsService.generateStatistics();
 
         assertNotNull(statistics.getInstanceUuid());
         assertEquals(0, statistics.getQueueSize());


### PR DESCRIPTION
Jira: IVP-1369

This allows clients (support) to query the ocr-api for the state of the service. The key statistic is the amount of messages waiting on an internal queue