### PR TITLE
Update logging to use in cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Set the environmental variables OCR_TESSERACT_THREAD_POOL_SIZE, HUMAN_LOG and LO
 
 ## Tesseract Training data
 
-This is used by the Tesseract engine to help in the text recognisition. We store the currently used data within configuration management for consistency and speed of the docker build.
+This is used by the Tesseract engine to help in the text recognition. We store the currently used data within configuration management for consistency and speed of the docker build.
 
 To Update the training data, download the `eng.traineddata` file from one of the following URL (note that using the "best" data slows down the time of the OCR conversion and has not yet be shown to significantly make it better):
 
 - [Standard data](https://github.com/tesseract-ocr/tessdata)
 - [Best data](https://github.com/tesseract-ocr/tessdata_best)
 
-Store the data file in `docker-resources/tessdata/` with a timestamp and adjust the Dockerfile to use it.
+Store the data file in `docker-resources/tessdata/` with a timestamp and adjust the Docker file to use it.
 
 ## Metadata
 

--- a/src/main/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.ocr.api.heathcheck;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,20 +10,25 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.ocr.api.OcrApiApplication;
+import uk.gov.companieshouse.ocr.api.statistics.StatisticsService;
 
 @RequestMapping("${api.endpoint}")
 @RestController
 public class HealthCheckController {
 
     public static final String HEALTH_CHECK_PARTIAL_URL = "/healthcheck";
-    public static final String HEALTH_CHECK_MESSAGE = "ALIVE";
+    public static final String HEALTH_CHECK_MESSAGE = "ocr-api is alive";
 
     private static final Logger LOG = LoggerFactory.getLogger(OcrApiApplication.APPLICATION_NAME_SPACE);
+
+    @Autowired
+    private StatisticsService statisticsService;
 
     @GetMapping(HEALTH_CHECK_PARTIAL_URL)
     public @ResponseBody ResponseEntity<String> heathCheck() {
 
-        LOG.info("Health Check called");
+        LOG.info("Health Statistics", statisticsService.generateStatistics().toMap());
+
         return new ResponseEntity<>(HEALTH_CHECK_MESSAGE, HttpStatus.OK);
     }
 

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrApiController.java
@@ -60,15 +60,19 @@ public class ImageOcrApiController {
 
         var timeOnQueueStopWatch = new StopWatch();
         timeOnQueueStopWatch.start();
-        var result = transformer.mapModelToApi( imageOcrService.extractTextFromImage(contextId, file, responseId, timeOnQueueStopWatch).join());
+        var textConversionResult =  imageOcrService.extractTextFromImage(contextId, file, responseId, timeOnQueueStopWatch).join();
+
+        var extractTextResult =  transformer.mapModelToApi(textConversionResult);
 
         controllerStopWatch.stop();
-        result.setTotalProcessingTimeMs(controllerStopWatch.getTime());
+        extractTextResult.setTotalProcessingTimeMs(controllerStopWatch.getTime());
+
+        var monitoringFields = new MonitoringFields(textConversionResult, extractTextResult);
     
         LOG.infoContext(contextId, "Finished file " + file.getOriginalFilename() + " - time to run " + (controllerStopWatch.getTime()) + " (ms) " + "[ " +
-           controllerStopWatch.toString() + "]", null);
+           controllerStopWatch.toString() + "]", monitoringFields.toMap());
 
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return new ResponseEntity<>(extractTextResult, HttpStatus.OK);
     }
 
     /*

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrService.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/ImageOcrService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.ocr.api.image.extracttext;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,7 +35,10 @@ public class ImageOcrService {
     extractTextFromImage(String contextId, MultipartFile file, String responseId, StopWatch timeOnQueueStopWatch) throws IOException {
 
         timeOnQueueStopWatch.stop();
-        LOG.infoContext(contextId, "Converting File to Text - Time waiting on queue " + timeOnQueueStopWatch.toString(), null);
+
+        var logDataMap = new HashMap<String, Object>();
+        logDataMap.put("timeOnExecuterQueue", Long.valueOf(timeOnQueueStopWatch.getTime()));
+        LOG.infoContext(contextId, "Converting File to Text - Time waiting on queue " + timeOnQueueStopWatch.toString(), logDataMap); 
 
         final var textConversionResult = new TextConversionResult(contextId, responseId, timeOnQueueStopWatch.getTime()); 
 

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFields.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFields.java
@@ -1,0 +1,69 @@
+package uk.gov.companieshouse.ocr.api.image.extracttext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MonitoringFields {
+
+
+    private final int averageConfidenceScore;
+
+    private final int lowestConfidenceScore;
+
+    private final long ocrProcessingTimeMs;
+
+    private final long totalProcessingTimeMs;   
+
+    private final long timeOnExecuterQueue;
+
+    private final Integer totalPages;
+
+    public MonitoringFields(TextConversionResult textConversionResult, ExtractTextResultDto extractTextResultDto) {
+
+        this.averageConfidenceScore = extractTextResultDto.getAverageConfidenceScore();
+        this.lowestConfidenceScore = extractTextResultDto.getLowestConfidenceScore();
+        this.ocrProcessingTimeMs = extractTextResultDto.getOcrProcessingTimeMs();
+        this.totalProcessingTimeMs = extractTextResultDto.getTotalProcessingTimeMs();
+        this.timeOnExecuterQueue = textConversionResult.getTimeOnExecuterQueue();
+        this.totalPages = textConversionResult.getTotalPages();
+    }
+
+    public int getAverageConfidenceScore() {
+        return averageConfidenceScore;
+    }
+
+    public int getLowestConfidenceScore() {
+        return lowestConfidenceScore;
+    }
+
+    public long getOcrProcessingTimeMs() {
+        return ocrProcessingTimeMs;
+    }
+
+    public long getTotalProcessingTimeMs() {
+        return totalProcessingTimeMs;
+    }
+
+    public long getTimeOnExecuterQueue() {
+        return timeOnExecuterQueue;
+    }
+
+    public Integer getTotalPages() {
+        return totalPages;
+    }
+
+    public Map<String, Object> toMap() {
+
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        map.put("averageConfidenceScore", averageConfidenceScore);
+        map.put("lowestConfidenceScore", lowestConfidenceScore);
+        map.put("ocrProcessingTimeMs", ocrProcessingTimeMs);
+        map.put("totalProcessingTimeMs", totalProcessingTimeMs);
+        map.put("timeOnExecuterQueue", timeOnExecuterQueue);
+        map.put("totalPages", totalPages);
+
+        return  map;        
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResult.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResult.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.ocr.api.image.extracttext;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,7 +48,7 @@ public class TextConversionResult {
     // Useful for logging the metadata via Structured logging
     public Map<String, Object> metaDataMap() {
 
-        var metadata = new HashMap<String, Object>();
+        Map<String, Object> metadata = new LinkedHashMap<>();
 
         metadata.put("timeOnExecuterQueue", Long.valueOf(timeOnExecuterQueue));
         metadata.put("extractTextWatch", extractTextWatch.toString());

--- a/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResult.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResult.java
@@ -67,12 +67,12 @@ public class TextConversionResult {
         return pageConfidences.size();
     }
 
-	public void addConfidence(float confidence) {
+    public void addConfidence(float confidence) {
         documentConfidence.addConfidenceValue(confidence);
         currentPageConfidence.addConfidenceValue(confidence);
-	}
+    }
 
-	public void addPage() {
+    public void addPage() {
         currentPageConfidence = new Confidence();
         pageConfidences.add(currentPageConfidence);
     }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDto.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsDto.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.ocr.api.statistics;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StatisticsDto {
@@ -37,6 +40,17 @@ public class StatisticsDto {
 
     public void setTesseractThreadPoolSize(int tesseractThreadPoolSize) {
         this.tesseractThreadPoolSize = tesseractThreadPoolSize;
+    }
+
+    public Map<String, Object> toMap() {
+
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        map.put("instanceUuid", instanceUuid);
+        map.put("queueSize", queueSize);
+        map.put("tesseractThreadPoolSize", tesseractThreadPoolSize);
+
+        return  map;        
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckControllerTest.java
@@ -26,26 +26,26 @@ import uk.gov.companieshouse.ocr.api.statistics.StatisticsService;
 class HealthCheckControllerTest {
 
     @Autowired
-	private MockMvc mockMvc;
+    private MockMvc mockMvc;
 
-	@MockBean
+    @MockBean
     private StatisticsService mockStatisticsService; // used in logging
-	
-	@Value("${api.endpoint}")
+    
+    @Value("${api.endpoint}")
     private String apiEndpoint;
 
-	@Test
-	void validateIsHealthy() throws Exception {
+    @Test
+    void validateIsHealthy() throws Exception {
 
-		StatisticsDto testStatistics = new StatisticsDto();
+        StatisticsDto testStatistics = new StatisticsDto();
         testStatistics.setInstanceUuid("test-uuid");
         testStatistics.setQueueSize(2);
         testStatistics.setTesseractThreadPoolSize(4);
 
         when(mockStatisticsService.generateStatistics()).thenReturn(testStatistics);
 
-           mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + HealthCheckController.HEALTH_CHECK_PARTIAL_URL))
-		   .andExpect(status().isOk())
-		   .andExpect(content().string(containsString(HealthCheckController.HEALTH_CHECK_MESSAGE)));
-	}
+        mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + HealthCheckController.HEALTH_CHECK_PARTIAL_URL))
+           .andExpect(status().isOk())
+           .andExpect(content().string(containsString(HealthCheckController.HEALTH_CHECK_MESSAGE)));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/heathcheck/HealthCheckControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.ocr.api.heathcheck;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
@@ -10,25 +11,38 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import uk.gov.companieshouse.ocr.api.groups.TestType;
+import uk.gov.companieshouse.ocr.api.statistics.StatisticsDto;
+import uk.gov.companieshouse.ocr.api.statistics.StatisticsService;
 
 @Tag(TestType.UNIT)
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = HealthCheckController.class)
-public class HealthCheckControllerTest {
+class HealthCheckControllerTest {
 
     @Autowired
 	private MockMvc mockMvc;
+
+	@MockBean
+    private StatisticsService mockStatisticsService; // used in logging
 	
 	@Value("${api.endpoint}")
     private String apiEndpoint;
 
 	@Test
 	void validateIsHealthy() throws Exception {
+
+		StatisticsDto testStatistics = new StatisticsDto();
+        testStatistics.setInstanceUuid("test-uuid");
+        testStatistics.setQueueSize(2);
+        testStatistics.setTesseractThreadPoolSize(4);
+
+        when(mockStatisticsService.generateStatistics()).thenReturn(testStatistics);
 
            mockMvc.perform(MockMvcRequestBuilders.get(apiEndpoint + HealthCheckController.HEALTH_CHECK_PARTIAL_URL))
 		   .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/ConfidenceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/ConfidenceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.ocr.api.groups.TestType;
 
 @Tag(TestType.UNIT)
-public class ConfidenceTest {
+class ConfidenceTest {
 
 	private Confidence confidence;
 
@@ -20,7 +20,7 @@ public class ConfidenceTest {
 	}
 
 	@Test
-	public void shouldaddThreeValuesOK() {
+	void shouldaddThreeValuesOK() {
 		
 		confidence.addConfidenceValue(62.2f);
 		confidence.addConfidenceValue(70.8f);
@@ -34,7 +34,7 @@ public class ConfidenceTest {
 	}
 
 	@Test
-	public void shouldWorkWithoutAddingValues() {
+	void shouldWorkWithoutAddingValues() {
 
 		assertNull(confidence.getAverage());
 		assertNull(confidence.getMinimum());

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFieldsTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFieldsTest.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.ocr.api.image.extracttext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.ocr.api.groups.TestType;
+
+@Tag(TestType.UNIT)
+class MonitoringFieldsTest {
+
+	private static final long TIME_ON_EXECUTOR_QUEUE = 500;
+	private static final int AVERAGE_CONFIDENCE_SCORE = 60;
+	private static final int LOWEST_CONFIDENCE_SCORE = 5;
+	private static final long OCR_PROCESSING_TIME_MS = 8321;
+	private static final long OCR_TOTAL_PROCESSING_TIME_MS = 8842;
+
+	@Test
+	void objectConstructed() {
+		
+		var textConversionResult = new TextConversionResult("context-id", "response-id", TIME_ON_EXECUTOR_QUEUE);
+        textConversionResult.addPage();
+		textConversionResult.addPage();
+
+		var extractTextResult = new ExtractTextResultDto();
+		extractTextResult.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
+		extractTextResult.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
+		extractTextResult.setOcrProcessingTimeMs(OCR_PROCESSING_TIME_MS);
+		extractTextResult.setTotalProcessingTimeMs(OCR_TOTAL_PROCESSING_TIME_MS);
+
+		var monitoringFields = new MonitoringFields(textConversionResult, extractTextResult);
+
+		assertEquals(TIME_ON_EXECUTOR_QUEUE, monitoringFields.getTimeOnExecuterQueue());
+		assertEquals(AVERAGE_CONFIDENCE_SCORE, monitoringFields.getAverageConfidenceScore());
+		assertEquals(LOWEST_CONFIDENCE_SCORE, monitoringFields.getLowestConfidenceScore());
+		assertEquals(OCR_PROCESSING_TIME_MS, monitoringFields.getOcrProcessingTimeMs());
+		assertEquals(OCR_TOTAL_PROCESSING_TIME_MS, monitoringFields.getTotalProcessingTimeMs());
+		assertEquals(2, monitoringFields.getTotalPages());
+
+	}
+
+}

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFieldsTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/MonitoringFieldsTest.java
@@ -10,34 +10,34 @@ import uk.gov.companieshouse.ocr.api.groups.TestType;
 @Tag(TestType.UNIT)
 class MonitoringFieldsTest {
 
-	private static final long TIME_ON_EXECUTOR_QUEUE = 500;
-	private static final int AVERAGE_CONFIDENCE_SCORE = 60;
-	private static final int LOWEST_CONFIDENCE_SCORE = 5;
-	private static final long OCR_PROCESSING_TIME_MS = 8321;
-	private static final long OCR_TOTAL_PROCESSING_TIME_MS = 8842;
+    private static final long TIME_ON_EXECUTOR_QUEUE = 500;
+    private static final int AVERAGE_CONFIDENCE_SCORE = 60;
+    private static final int LOWEST_CONFIDENCE_SCORE = 5;
+    private static final long OCR_PROCESSING_TIME_MS = 8321;
+    private static final long OCR_TOTAL_PROCESSING_TIME_MS = 8842;
 
-	@Test
-	void objectConstructed() {
-		
-		var textConversionResult = new TextConversionResult("context-id", "response-id", TIME_ON_EXECUTOR_QUEUE);
+    @Test
+    void objectConstructed() {
+        
+        var textConversionResult = new TextConversionResult("context-id", "response-id", TIME_ON_EXECUTOR_QUEUE);
         textConversionResult.addPage();
-		textConversionResult.addPage();
+        textConversionResult.addPage();
 
-		var extractTextResult = new ExtractTextResultDto();
-		extractTextResult.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
-		extractTextResult.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
-		extractTextResult.setOcrProcessingTimeMs(OCR_PROCESSING_TIME_MS);
-		extractTextResult.setTotalProcessingTimeMs(OCR_TOTAL_PROCESSING_TIME_MS);
+        var extractTextResult = new ExtractTextResultDto();
+        extractTextResult.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
+        extractTextResult.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
+        extractTextResult.setOcrProcessingTimeMs(OCR_PROCESSING_TIME_MS);
+        extractTextResult.setTotalProcessingTimeMs(OCR_TOTAL_PROCESSING_TIME_MS);
 
-		var monitoringFields = new MonitoringFields(textConversionResult, extractTextResult);
+        var monitoringFields = new MonitoringFields(textConversionResult, extractTextResult);
 
-		assertEquals(TIME_ON_EXECUTOR_QUEUE, monitoringFields.getTimeOnExecuterQueue());
-		assertEquals(AVERAGE_CONFIDENCE_SCORE, monitoringFields.getAverageConfidenceScore());
-		assertEquals(LOWEST_CONFIDENCE_SCORE, monitoringFields.getLowestConfidenceScore());
-		assertEquals(OCR_PROCESSING_TIME_MS, monitoringFields.getOcrProcessingTimeMs());
-		assertEquals(OCR_TOTAL_PROCESSING_TIME_MS, monitoringFields.getTotalProcessingTimeMs());
-		assertEquals(2, monitoringFields.getTotalPages());
+        assertEquals(TIME_ON_EXECUTOR_QUEUE, monitoringFields.getTimeOnExecuterQueue());
+        assertEquals(AVERAGE_CONFIDENCE_SCORE, monitoringFields.getAverageConfidenceScore());
+        assertEquals(LOWEST_CONFIDENCE_SCORE, monitoringFields.getLowestConfidenceScore());
+        assertEquals(OCR_PROCESSING_TIME_MS, monitoringFields.getOcrProcessingTimeMs());
+        assertEquals(OCR_TOTAL_PROCESSING_TIME_MS, monitoringFields.getTotalProcessingTimeMs());
+        assertEquals(2, monitoringFields.getTotalPages());
 
-	}
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResultTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/image/extracttext/TextConversionResultTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.ocr.api.groups.TestType;
 
 @Tag(TestType.UNIT)
-public class TextConversionResultTest {
+class TextConversionResultTest {
 
     private static final String CONTEXT_ID = "test-context-id";
     private static final String RESPONSE_ID = "test-response-id";

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsControllerTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.ocr.api.groups.TestType;
 @Tag(TestType.UNIT)
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = StatisticsController.class)
-public class StatisticsControllerTest {
+class StatisticsControllerTest {
 
     private final static String TEST_UUID = "UUID_123";
     private final static int TEST_QUEUE_SIZE = 1;

--- a/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/statistics/StatisticsServiceTest.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.ocr.api.groups.TestType;
 
 @Tag(TestType.UNIT)
 @ExtendWith(MockitoExtension.class)
-public class StatisticsServiceTest {
+class StatisticsServiceTest {
 
     private final static int TEST_TESSERACT_POOL_SIZE = 3;
 


### PR DESCRIPTION
ivp 1430

CloudWatch works best when you log your data in the map portion of the CH Structured Logging API. Changes were therefore  made accordingly (including logging statistics when doing the heathcheck that is called via the load balaner so that we can track time on internal Queue over time)

Also removed some sonar warnings for test classes