### PR TITLE
Add low confidence score logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ The following is a list of application specific environment variables for the se
 
 Name                                        | Description                                                               | Example Value
 ------------------------------------------- | ------------------------------------------------------------------------- | ------------------------
-OCR_TESSERACT_THREAD_POOL_SIZE              | Number of threads to run the Tesseract Conversion process                 | 4  (default value)
-OCR_QUEUE_CAPACITY                          | Maximum number of OCR Requests in the OCR Queue before a 503 is returned  | 5
+LOW_CONFIDENCE_TO_LOG                       | The minimum confidence value used for logging low confidence scores (logs lines with lower scores than the value set) | 40
+OCR_TESSERACT_THREAD_POOL_SIZE              | Number of threads to run the Tesseract Conversion process                                                             | 4  (default value)
+OCR_QUEUE_CAPACITY                          | Maximum number of OCR Requests in the OCR Queue before a 503 is returned                                              | 5
 
 ## The stats end point
 

--- a/src/main/java/uk/gov/companieshouse/ocr/api/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/SpringConfiguration.java
@@ -1,17 +1,14 @@
 package uk.gov.companieshouse.ocr.api;
 
-import java.time.Duration;
-
-import javax.annotation.PostConstruct;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
-
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import javax.annotation.PostConstruct;
+import java.time.Duration;
 
 @Configuration
 public class SpringConfiguration {
@@ -21,6 +18,9 @@ public class SpringConfiguration {
 
     @Value("${rest.client.timeout.seconds}")
     private int restClientTimeoutSeconds;
+
+    @Value("${low.confidence.to.log}")
+    private int lowConfidenceToLog;
 
     private static final Logger LOG = LoggerFactory.getLogger(OcrApiApplication.APPLICATION_NAME_SPACE);
 
@@ -37,6 +37,7 @@ public class SpringConfiguration {
 		LOG.info("-------------------- Displaying spring application.properties  ----------------------------------");
 
         LOG.info("The value of ${ocr.queue.capacity} is          :     " + ocrQueueCapacity);
+        LOG.info("The value of ${low.confidence.to.log} is       :     " + lowConfidenceToLog);
         LOG.info("The value of ${rest.client.timeout.seconds} is :     " + restClientTimeoutSeconds);
 
 		LOG.info("-------------------- End displaying spring application.properties  ----------------------------------");
@@ -46,4 +47,7 @@ public class SpringConfiguration {
         return ocrQueueCapacity;
     }
 
+    public int getLowConfidenceToLog() {
+        return lowConfidenceToLog;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/ocr/api/common/JsonConstants.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/common/JsonConstants.java
@@ -6,17 +6,21 @@ public final class JsonConstants {
     public static final String ACTIVE_POOL_SIZE_NAME = "active_pool_size";
     public static final String AVERAGE_CONFIDENCE_SCORE_NAME ="average_confidence_score";
     public static final String CALL_TYPE_NAME = "call_type";
+    public static final String CONFIDENCE_VALUE_NAME = "confidence_value";
     public static final String CONTEXT_ID = "context_id";
+    public static final String CONVERTED_TEXT_NAME = "converted_text";
     public static final String CLIENT_IP_NAME = "client_ip";
     public static final String FILE_CONTENT_TYPE_NAME = "file_content_type";
     public static final String FILE_SIZE_NAME = "file_size";
     public static final String HTTP_REFERER_NAME = "http_referer";
     public static final String INSTANCE_UUID_NAME = "instance_uuid";
+    public static final String LINE_NUMBER_NAME = "line_number";
     public static final String LOWEST_CONFIDENCE_SCORE_NAME = "lowest_confidence_score";
     public static final String OCR_PROCESSING_TIME_MS_NAME = "ocr_processing_time_ms";
     public static final String LARGEST_POOL_SIZE_NAME = "largest_pool_size";
     public static final String MAX_POOL_SIZE_NAME = "max_pool_size";
     public static final String ORIGINAL_FILENAME_NAME = "original_filename";
+    public static final String PAGE_NUMBER_NAME = "page_number";
     public static final String POOL_SIZE_NAME = "pool_size";
     public static final String PROCESSORS_NAME = "processors_size";
     public static final String QUEUE_CAPACITY_NAME = "queue_capacity";
@@ -37,6 +41,7 @@ public final class JsonConstants {
     public static final String STATISTICS_LOG_RECORD = "ocr_statistics";
     public static final String THREAD_POOL_EXECUTOR_CONFIG_LOG_RECORD = "thread_pool_executor_config";
     public static final String POST_QUEUE_LOG_RECORD = "post_queue";
+    public static final String LOW_CONFIDENCE_LOG_RECORD = "low_confidence";
 
     private JsonConstants(){}
     

--- a/src/main/java/uk/gov/companieshouse/ocr/api/healthcheck/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/ocr/api/healthcheck/HealthCheckController.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.ocr.api.heathcheck;
+package uk.gov.companieshouse.ocr.api.healthcheck;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 api.endpoint=/ocr-api
 
 ocr.queue.capacity=${OCR_QUEUE_CAPACITY}
+low.confidence.to.log=${LOW_CONFIDENCE_SCORE_TO_LOG}
 
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB

--- a/src/test/java/uk/gov/companieshouse/ocr/api/healthcheck/HealthCheckControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocr/api/healthcheck/HealthCheckControllerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.ocr.api.heathcheck;
+package uk.gov.companieshouse.ocr.api.healthcheck;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Add 'low confidence log record'

Log the page number, line number, confidence and line text when a line's confidence score is less than the LOW_CONFIDENCE_TO_LOG environment variable.