### PR TITLE
Fixes security vulnerability in log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -17,21 +17,22 @@
 
     <properties>
         <java.version>11</java.version>
-        
+
         <included.tests>unit-test</included.tests>
 
         <apache-commons-lang.version>2.6</apache-commons-lang.version>
         <environment-reader.version>1.3.8</environment-reader.version>
-        <structured-logging.version>1.9.4</structured-logging.version>
+        <structured-logging.version>1.9.10</structured-logging.version>
         <tess4j.version>4.5.3</tess4j.version>
+        <log4j-bom.version>2.15.0</log4j-bom.version>
 
         <!-- Spring General -->
         <spring.boot.version>2.4.2</spring.boot.version>
 
-         <!-- Maven -->
-         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
+        <!-- Maven -->
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
     </properties>
 
     <profiles>
@@ -45,6 +46,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -88,20 +96,20 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
-         </dependency>     
+        </dependency>
 
-         <dependency>
+        <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>environment-reader-library</artifactId>
             <version>${environment-reader.version}</version>
         </dependency>
-         
-         <!-- needed to add this for CH structured logging (errors on v3 of this linrary-->
-         <dependency> 
-            <groupId>commons-lang</groupId> 
-            <artifactId>commons-lang</artifactId> 
+
+        <!-- needed to add this for CH structured logging (errors on v3 of this linrary-->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
             <version>${apache-commons-lang.version}</version>
-        </dependency> 
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -116,26 +124,26 @@
         </dependency>
 
         <dependency>
-	      <groupId>org.junit.jupiter</groupId>
-	      <artifactId>junit-jupiter-engine</artifactId>
-	      <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
-         </dependency>
+        </dependency>
 
-         <dependency>
+        <dependency>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
         </dependency>
 
-        
+
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -163,11 +171,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                  <source>${java.version}</source>
-                  <target>${java.version}</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
-Updates log4j to version 2.15.0 using log4j-bom.
This has been explicitly added to the pom due to springboot dependency
management bringing in old version of log4j regardless of what is being
used in structured-logging.

-This will need to be removed when springboot has been updated 2.5.8 or
2.6.2. More information can be found here: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

-Updates structured-logging version to 1.9.10

Resolves: DEBT-1457