### PR TITLE
Upgrade log4j and structured logging version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These key log messages contain a map of values that can be used by systems such 
 
 ## Usage
 
-Set the environmental variables `OCR_TESSERACT_THREAD_POOL_SIZE`, `OCR_QUEUE_CAPACITY`, `HUMAN_LOG` and `LOGLEVEL`
+Set the environmental variables `OCR_TESSERACT_THREAD_POOL_SIZE`, `OCR_QUEUE_CAPACITY`, `LOW_CONFIDENCE_TO_LOG`, `HUMAN_LOG` and `LOGLEVEL`
 
 - Run `make dev` to build JAR (versioned in target and unversioned in top level d) and run the unit tests **(using Java 11)**
 - Run `docker build -t ocr-api .` to build the docker image

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
         <apache-commons-lang.version>2.6</apache-commons-lang.version>
         <environment-reader.version>1.3.8</environment-reader.version>
-        <structured-logging.version>1.9.11</structured-logging.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
         <tess4j.version>4.5.3</tess4j.version>
         <log4j-bom.version>2.17.0</log4j-bom.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <environment-reader.version>1.3.8</environment-reader.version>
         <structured-logging.version>1.9.11</structured-logging.version>
         <tess4j.version>4.5.3</tess4j.version>
-        <log4j-bom.version>2.16.0</log4j-bom.version>
+        <log4j-bom.version>2.17.0</log4j-bom.version>
 
         <!-- Spring General -->
         <spring.boot.version>2.4.2</spring.boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <environment-reader.version>1.3.8</environment-reader.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <tess4j.version>4.5.3</tess4j.version>
-        <log4j-bom.version>2.17.0</log4j-bom.version>
 
         <!-- Spring General -->
         <spring.boot.version>2.4.2</spring.boot.version>
@@ -46,13 +45,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
- Upgrade log4j version to 2.17.0
- Upgrade structured-logging version to 1.9.12

Output of `mvn dependency:tree | grep log4j`:
```
[INFO] |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.0:compile
[INFO] |  |  |  \- org.apache.logging.log4j:log4j-api:jar:2.17.0:compile
[INFO] |  |  +- log4j:log4j:jar:1.2.17:compile
```

Resolves DEBT-1586.