### PR TITLE
Bump json dependency from 20180130 to 20230227

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
+            <version>20230227</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
JIRA ticket

[BI-13680](https://companieshouse.atlassian.net/browse/BI-13680)

Short description
Bump json dependency from 20180130 to 20230227 to fix security vulnerabilities

[BI-13680]: https://companieshouse.atlassian.net/browse/BI-13680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ